### PR TITLE
Remove RedBean

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,6 @@
     "spomky-labs/otphp": "*",
     "spatie/db-dumper": "*",
     "robmorgan/phinx": "*",
-    "gabordemooij/redbean": "*",
     "firebase/php-jwt": "^6.11",
     "vlucas/phpdotenv": "^5.6"
   },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "898a11e3b94152374dfdad181a8144d3",
+    "content-hash": "fa6009c7738e6f52843de89720ba889a",
     "packages": [
         {
             "name": "cakephp/chronos",
@@ -626,51 +626,6 @@
                 "source": "https://github.com/firebase/php-jwt/tree/v6.11.1"
             },
             "time": "2025-04-09T20:32:01+00:00"
-        },
-        {
-            "name": "gabordemooij/redbean",
-            "version": "v5.7.5",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/gabordemooij/redbean.git",
-                "reference": "fc08c2f9bc5a4f5074721b0d9039881be244f842"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/gabordemooij/redbean/zipball/fc08c2f9bc5a4f5074721b0d9039881be244f842",
-                "reference": "fc08c2f9bc5a4f5074721b0d9039881be244f842",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.4"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "RedBeanPHP\\": "RedBeanPHP"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Gabor de Mooij",
-                    "email": "gabor@redbeanphp.com",
-                    "homepage": "https://redbeanphp.com"
-                }
-            ],
-            "description": "RedBeanPHP ORM",
-            "homepage": "https://redbeanphp.com/",
-            "keywords": [
-                "orm"
-            ],
-            "support": {
-                "issues": "https://github.com/gabordemooij/redbean/issues",
-                "source": "https://github.com/gabordemooij/redbean/tree/v5.7.5"
-            },
-            "time": "2025-05-01T17:41:56+00:00"
         },
         {
             "name": "graham-campbell/result-type",


### PR DESCRIPTION
This pull request makes a small change to the `composer.json` file, removing the `gabordemooij/redbean` package from the list of dependencies. This helps to clean up unused or unnecessary dependencies.